### PR TITLE
docs: add data loader API guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,60 @@ Streamlined tools for downloading, validating, and transforming FHFA-related dat
 
 - See `AGENTS.md` for project structure, commands, coding style, testing, and PR conventions.
 
+## Data Loader API
+
+The `data_loaders.py` module now wraps FHFA and FHLB ETL tasks in reusable
+classes so notebooks and scripts can share the same orchestration logic.
+
+### Configuration helpers
+
+- `PathsConfig` centralizes directory discovery using environment variables
+  (`PROJECT_DIR`, `DATA_DIR`, `FHFA_RAW_DIR`, `FHFA_CLEAN_DIR`). Call
+  `PathsConfig.from_env()` to materialize a configuration with sensible
+  defaults when the variables are absent.
+- `ImportOptions` exposes operational flags (overwrite behaviour, download
+  pauses, Excel engine) that can be passed into each loader for customization.
+
+### FHFADataLoader
+
+`FHFADataLoader` gathers FHFA-specific helpers:
+
+- Resolve dictionary files for raw text releases via
+  `resolve_dictionary_for_data_file` / `resolve_dictionaries_for_year_folder`.
+- Download the latest ZIPs and dictionary PDFs, extract tables, and persist the
+  parsed results as CSV and/or Parquet.
+- Load fixed-width text files into Polars DataFrames with schema/width metadata
+  sourced from the parsed dictionaries, then optionally convert entire year
+  folders into compressed Parquet datasets.
+
+### FHLBDataLoader
+
+`FHLBDataLoader` mirrors the FHFA loader for Federal Home Loan Bank artefacts:
+
+- Download CSV releases from the FHFA portal with substring filtering.
+- Combine quarterly member spreadsheets across multiple years with consistent
+  field naming and date normalization.
+- Import and clean acquisitions data using the shared dictionary mappings, and
+  emit per-year as well as combined outputs.
+
+### Example
+
+```python
+from pathlib import Path
+
+from data_loaders import PathsConfig, FHFADataLoader
+
+paths = PathsConfig.from_env()
+fhfa_loader = FHFADataLoader(paths)
+
+mapping = fhfa_loader.resolve_dictionaries_for_year_folder(2023)
+for data_path, dict_path in mapping.items():
+    if dict_path is None:
+        continue
+    table = fhfa_loader.load_fixed_width_dataset(data_path, dict_path)
+    table.write_parquet(Path(paths.clean_dir) / f"{data_path.stem}.parquet")
+```
+
 ## Notes
 
 - Do not commit data or secrets. `data/` and `.env*` are ignored by default (see `.gitignore`).


### PR DESCRIPTION
## Summary
- describe the configuration helpers introduced in `data_loaders.py`
- outline the major FHFADataLoader and FHLBDataLoader capabilities
- include a usage example that shows how to resolve dictionaries and load data

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d7de0e1fe08332ae6f8d01110f1ef2